### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ FastReport       431.4 ms                      433.4 ms                     +983
 
 ## Converting the output into JSON format
 
-The `make_circles.py` requires two input files: the output of the CMSSW job, and thecorrespondig fully-expanded python configuration file, which is used to associate
+The `make_circles.py` requires two input files: the output of the CMSSW job, and the corresponding fully-expanded python configuration file (use `edmConfigDump` on configs created with `cmsDriver.py`), which is used to associate
 the C++ type to each module.
 
-The ouptut is structured in a hierarchidefined by
+The output is structured in a hierarchy defined by
   - the module group;
   - the module C++ type;
   - the individual module.
@@ -110,5 +110,6 @@ Just copy the `web/` drectory to a web server, and enable support for cgi-bin sc
 ## Uploading the data to a web server
 
 Copy the JSON files produced by `make_circles.py` to the `data/` subdirectory, and refresh the web page.
-They files will automatically appear in the "Datasets" drop-down box.
+The files will automatically appear in the "Datasets" drop-down box.
 Select one to visualise its content in the interactive plot.
+(Alternatively, append `?dataset=x` to the URL, where `x` is the name of the dataset.)

--- a/make_circles.py
+++ b/make_circles.py
@@ -267,13 +267,13 @@ def build_module_hierarchy(data, types, groups):
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description = 'Parse the FastReport in one or more CMSSW log files, and write a JSON representation to the standard output or a file.')
 
-  parser.add_argument('--groups', '-g', dest = 'groups', action = 'store', type = argparse.FileType('r'), default = 'groups.csv',
-                      help = 'a CSV file describing the grouing of modules (default is \'groups.csv\').')
+  parser.add_argument('--groups', '-g', dest = 'groups', action = 'store', type = argparse.FileType('r'), required = True,
+                      help = 'a CSV file describing the grouping of modules (required).')
 
   parser.add_argument('--colours', '-C', dest = 'colours', action = 'store', type = argparse.FileType('r'), default = 'colours.csv',
-                      help = 'a CSV file describing the colours used to draw each group (default is \'colours.csv\'.')
+                      help = 'a CSV file describing the colours used to draw each group (default is \'colours.csv\').')
 
-  parser.add_argument('--config', '-c', dest = 'config', action = 'store',
+  parser.add_argument('--config', '-c', dest = 'config', action = 'store', required = True,
                       help = 'required: the CMSSW configuration file corresponding to the log file(s) being processed.')
 
   parser.add_argument('--output', '-o', dest = 'json', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout,


### PR DESCRIPTION
I noticed that the `--help` option in `make_circles.py` did not work, because the arguments of type `argparse.FileType()` try to open their default values during parsing, and the file `groups.csv` does not exist. Instead of providing a nonexistent default, I just marked the argument as required. I did the same for the config argument, which was described as required.

I also added a few pieces of useful info in the readme:
* note that `edmConfigDump` should be used on configs generated by `cmsDriver.py`
* syntax to append dataset directly to the URL

In addition, I fixed a few typos.