### PR TITLE
assign `L1TGlobalSummary` to L1-Trigger

### DIFF
--- a/web/groups/hlt.json
+++ b/web/groups/hlt.json
@@ -365,7 +365,7 @@
   "L1TEnergySumFilter|": "L1T",
   "L1TExtCondProducer|": "L1T",
   "L1TGlobalProducer|": "L1T",
-  "L1TGlobalSummary|": "Taus",
+  "L1TGlobalSummary|": "L1T",
   "L1THLTTauMatching|": "Taus",
   "L1TJetFilter|": "L1T",
   "L1TMuonBarrelKalmanStubProducer|": "L1T",

--- a/web/groups/hlt_no_gpu.json
+++ b/web/groups/hlt_no_gpu.json
@@ -353,7 +353,7 @@
   "L1TEnergySumFilter|": "L1T",
   "L1TExtCondProducer|": "L1T",
   "L1TGlobalProducer|": "L1T",
-  "L1TGlobalSummary|": "Taus",
+  "L1TGlobalSummary|": "L1T",
   "L1THLTTauMatching|": "Taus",
   "L1TJetFilter|": "L1T",
   "L1TMuonBarrelKalmanStubProducer|": "L1T",


### PR DESCRIPTION
`L1TGlobalSummary` is a thread-unfriendly `edm::one` module, but the TAU POG should not be blamed for this.