### PR TITLE
Add support for custom resource

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -1,0 +1,6 @@
+<?php 
+
+header("Location:piechart.php"); 
+exit;
+
+?>

--- a/web/piechart.php
+++ b/web/piechart.php
@@ -352,18 +352,23 @@
         while (menu.length) {
           menu.remove(0);
         }
-
-        // Extract the available resources from the input, and select the first one by default
         var resources = current.dataset.resources;
         for (var i = 0; i < resources.length; i++) {
-          for (key in resources[i]) {
-            var entry = document.createElement("option");
-            entry.text = resources[i][key];
-            entry.value = key;
-            menu.add(entry);
-            if (key == config.resource) {
-              menu.selectedIndex = i;
-            }
+          var entry = document.createElement("option");
+          var key = Object.keys(resources[i])[0];
+          entry.text = resources[i][key];
+          entry.value = key;
+          if (resources[i].unit != null)
+            entry.unit = resources[i].unit;
+          else
+            entry.unit = "";
+          if (resources[i].title != null)
+            entry.title = resources[i].title;
+          else
+            entry.title = "";
+          menu.add(entry);
+          if (key == config.resource) {
+            menu.selectedIndex = i;
           }
         }
 
@@ -376,21 +381,24 @@
         var menu = document.getElementById("metric_menu");
         var index = menu.selectedIndex;
         config.resource = menu.options[index].value;
-        current.metric = menu.options[index].text
-        if (config.resource.startsWith("hs23_")) {
-          current.unit = " HS23/Hz";
-          current.title = "Capacity";
-        } else if (config.resource.startsWith("time_")) {
-          current.unit = " ms";
-          current.title = "Time";
-        } else if (config.resource.startsWith("mem_")) {
-          current.unit = " kB";
-          current.title = "Memory";
-        } else {
-          current.unit = "";
-          current.title = "";
+        current.metric = menu.options[index].text;
+        current.unit = menu.options[index].unit;
+        current.title = menu.options[index].title;
+        if (current.unit == null || current.title == null) {
+          if (config.resource.startsWith("hs23_")) {
+            current.unit = " HS23/Hz";
+            current.title = "Capacity";
+          } else if (config.resource.startsWith("time_")) {
+            current.unit = " ms";
+            current.title = "Time";
+          } else if (config.resource.startsWith("mem_")) {
+            current.unit = " kB";
+            current.title = "Memory";
+          } else {
+            current.unit = "";
+            current.title = "";
+          }
         }
-
         updatePage();
       }
 

--- a/web/piechart.php
+++ b/web/piechart.php
@@ -355,20 +355,27 @@
         var resources = current.dataset.resources;
         for (var i = 0; i < resources.length; i++) {
           var entry = document.createElement("option");
-          var key = Object.keys(resources[i])[0];
-          entry.text = resources[i][key];
-          entry.value = key;
-          if (resources[i].unit != null)
-            entry.unit = resources[i].unit;
-          else
-            entry.unit = "";
-          if (resources[i].title != null)
+          var keys = Object.keys(resources[i]);
+          // if you find description title name and unit use them
+          if (keys.includes("description") && keys.includes("title") && keys.includes("name") && keys.includes("unit")) {
+            entry.text = resources[i].description;
+            entry.value = resources[i].name;
             entry.title = resources[i].title;
-          else
-            entry.title = "";
-          menu.add(entry);
-          if (key == config.resource) {
-            menu.selectedIndex = i;
+            entry.unit = resources[i].unit;
+            menu.add(entry);
+            if (key == config.resource) {
+              menu.selectedIndex = i;
+            }
+          } else {
+            for (key in resources[i]) {
+            var entry = document.createElement("option");
+            entry.text = resources[i][key];
+            entry.value = key;
+            menu.add(entry);
+            if (key == config.resource) {
+              menu.selectedIndex = i;
+            }
+          }
           }
         }
 

--- a/web/piechart.php
+++ b/web/piechart.php
@@ -205,6 +205,12 @@
       // Circles data view
       var circles = null;
 
+
+      function escape(text) {
+        return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      }
+
+
       function embed() {
         // We respin until the visualization container has non-zero area (there are race
         // conditions on Chrome which permit that) and the visualization class is loaded.
@@ -252,7 +258,7 @@
             var group = attrs.hoverGroup;
             var value = fixed(group.weight) + current.unit;
             var percent = fixed(group.weight / total * 100.) + " %";
-            table.row.add( [ group.label, value, percent ] );
+            table.row.add( [ escape(group.label), value, percent ] );
             attrs.label = value;
           } else if (attrs.selectedGroups.length > 0) {
             var sum = 0.;
@@ -261,7 +267,7 @@
               var value = fixed(group.weight) + current.unit;
               var percent = fixed(group.weight / total * 100.) + " %";
               sum += group.weight;
-              table.row.add( [ group.label, value, percent ] );
+              table.row.add( [ escape(group.label), value, percent ] );
               attrs.label = value;
             }
             if (attrs.selectedGroups.length > 1) {
@@ -281,7 +287,7 @@
               var group = groups[i];
               var value = fixed(group.weight) + current.unit;
               var percent = fixed(group.weight / total * 100.) + " %";
-              table.row.add( [ group.label, value, percent ] );
+              table.row.add( [ escape(group.label), value, percent ] );
             }
             var label   = "total";
             var value   = fixed(total) + current.unit;
@@ -754,7 +760,7 @@
 
       circles.set("onGroupHover", function(hover) {
         if (hover.group) {
-          tooltip.innerHTML = hover.group.label + "<br>" + hover.group.weight.toFixed(1) + " " + current.unit;
+          tooltip.innerHTML = escape(hover.group.label) + "<br>" + hover.group.weight.toFixed(1) + " " + current.unit;
           if ("events" in hover.group) {
             tooltip.innerHTML += "<br>" + (hover.group.events * 100.).toFixed(1) + "% events";
           }


### PR DESCRIPTION
Add support for custom resources by introducing a new way to define them in the json file.

For example:
```
"resources": [
{
"name": "size_uncompressed",
"description" : "uncompressed size",
"unit" : "B",
"title" : "Data Size"
},
{
"name":"size_compressed",
"description": "compressed size",
"unit" : "B",
"title" : "Data Size"
}
],
```

Support "old" format if the keys name, description, unit and title are not defined.
Set correct unit of measure in the circles label and in the tooltips.

In addition (sorry if it's the same PR) handles comparison symbles (`<` `>`) in label and type name and add compression ratio in tooltip when available.
