### PR TITLE
add color reference validation to JSON lint workflow

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -25,3 +25,21 @@ jobs:
             echo "Checking $file"
             jq empty "$file"
           done
+
+      - name: Validate color references
+        shell: bash
+        run: |
+          valid_colors=$(jq -r 'keys[]' web/colours/default.json | sort)
+          for file in web/groups/hlt*.json; do
+            echo "Validating color references in $file"
+            jq -r 'to_entries[] | .value' "$file" 2>/dev/null | while read -r value; do
+              if [ -n "$value" ] && [ "$value" != "null" ]; then
+                # Extract color name before the | character (e.g., "HLT|GPU" -> "HLT")
+                color_name="${value%%|*}"
+                if ! echo "$valid_colors" | grep -q "^${color_name}$"; then
+                  echo "ERROR: Invalid color reference '$color_name' in $file"
+                  exit 1
+                fi
+              fi
+            done
+          done

--- a/web/colours/default.json
+++ b/web/colours/default.json
@@ -1,6 +1,7 @@
 {
   "AlCa": "#ff9999",
   "B tagging": "#663300",
+  "CTPPS": "#8A2BE2",
   "DQM": "#a00000",
   "E/Gamma": "#ffee00",
   "ECAL": "#4ddbff",
@@ -19,6 +20,7 @@
   "Tracking": "#009900",
   "Full track and vertex": "#009900",
   "Vertices": "#006600",
+  "ZDC": "#008B8B",
 
   "Pixels on GPU": "#33ff33",
   "ECAL on GPU": "#4ddbff",


### PR DESCRIPTION
Title says it all. Add checks that all the entries in the file are assigned to a valid category (i.e. mapped to a color).